### PR TITLE
Test socket is null when dispose

### DIFF
--- a/Meteor.DDP/DdpClient.cs
+++ b/Meteor.DDP/DdpClient.cs
@@ -206,7 +206,10 @@ namespace Meteor.DDP
 
         public void Dispose()
         {
-            this._socket.Dispose();
+            if (this._socket != null) 
+            {
+                this._socket.Dispose();
+            }
         }
 
         public WebSocketState WebSocketState


### PR DESCRIPTION
If server is not available, the dispose method creat an exception with "Object instance not set". So the test will prevent this exception.
